### PR TITLE
Use Paramiko instead of OpenSSH

### DIFF
--- a/jetstreamiuenv/playbook.yml
+++ b/jetstreamiuenv/playbook.yml
@@ -5,6 +5,7 @@
   remote_user: centos
   become: yes
   become_method: sudo
+  connection: paramiko
   pre_tasks:
     - name: Locate secret group variable files
       local_action:


### PR DESCRIPTION
Paramiko does not use pipelining so this way disabling tty task
can be done using Ansible.