### PR TITLE
Fix the task that acquires hostlist for a controller that has no workers

### DIFF
--- a/jetstream_common/templates/slurm/slurm.conf.j2
+++ b/jetstream_common/templates/slurm/slurm.conf.j2
@@ -40,12 +40,14 @@ ReturnToService=1
 NodeName={{ hostvars[host]['inventory_hostname_short'] }} NodeAddr={{ hostvars[host]['ansible_host'] }} RealMemory={{ node_type.real_memory }} Sockets={{ node_type.sockets }} CoresPerSocket=1 ThreadsPerCore=1 State=UNKNOWN
 {% endfor %}
 {% endfor %}
+# Needed when setting up a controller without workers
+NodeName=placeholder CPUs=64 State=future
 #
 # Partition Configurations
 #
 {# well this is less than ideal, it should loop partitions, and then generate a hostlist for that partition. but this works for now... #}
 {% for node_type in slurm_nodes %}
-PartitionName=multi State=UP MaxTime=48:20:00 MaxNodes=1 Nodes={{ slurm_hostlists.results[0].stdout }}
+PartitionName=multi State=UP MaxTime=48:20:00 MaxNodes=1 Nodes={{ slurm_hostlists.results[0].stdout | default( 'placeholder') }}
 {% endfor %}
 
 SlurmctldDebug=7

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -40,8 +40,9 @@
 
 - name: Acquire hostlist
   command: scontrol show hostlist {{ groups[item.inventory_group] | join(",") }}
-  with_items: slurm_nodes
+  with_items: "{{ slurm_nodes }}"
   register: slurm_hostlists
+  when: num_nodes.0 is defined
 
 - name: Install slurm.conf
   template:


### PR DESCRIPTION
Otherwise, running this role on a brand new server was reporting:
```
failed: [jetstream-iu0.galaxyproject.org] (item={u'partition': u'large', u'sockets': 10, u'inventory_group': u'jetstream-iu-large', u'real_memory': 29997}) => {"changed": true, "cmd": ["scontrol", "show", "hostlist"], "delta": "0:00:59.013009", "end": "2016-10-04 19:50:02.470360", "failed": true, "item": {"inventory_group": "jetstream-iu-large", "partition": "large", "real_memory": 29997, "sockets": 10}, "rc": 1, "start": "2016-10-04 19:49:03.457351", "stderr": "scontrol: error: s_p_parse_file: unable to status file /etc/slurm/slurm.conf: No such file or directory, retrying in 1sec up to 60sec\nscontrol: fatal: Unable to process configuration file", "stdout": "", "stdout_lines": [], "warnings": []}
```

This also fixes the bare variable deprecation warning.