### PR TITLE
disable influxdb max-row-limit

### DIFF
--- a/roles/stats/templates/influxdb.conf.j2
+++ b/roles/stats/templates/influxdb.conf.j2
@@ -69,7 +69,7 @@ join = ""
   pprof-enabled = false
   https-enabled = false
   https-certificate = "/etc/ssl/influxdb.pem"
-  max-row-limit = 10000
+  max-row-limit = 0
 
 [[graphite]]
   enabled = false


### PR DESCRIPTION
to prevent data being cut off from display

maybe we will need a limit eventually, but 10k seems too low