### PR TITLE
Pass range headers and prevent caching ranges

### DIFF
--- a/env/galaxy/templates/nginx/training.j2
+++ b/env/galaxy/templates/nginx/training.j2
@@ -53,6 +53,8 @@ server {
         proxy_hide_header      x-amz-server-side-encryption;
         proxy_hide_header      Set-Cookie;
         proxy_ignore_headers   Set-Cookie;
+        proxy_set_header       Range $http_range;
+        proxy_set_header       If-Range $http_if_range;
         proxy_cache_revalidate on;
         #proxy_intercept_errors on;
         #proxy_cache_use_stale  error timeout updating http_500 http_502 http_503 http_504;


### PR DESCRIPTION
Chrome disables seeking of videos if the server does not respond with 206 to the intial request (it sends `Ranges: bytes=0-`). We failed to pass this and S3 was sending back 200 ok, and the whole file. Let's ship those headers! :revolving_hearts:

Not convinced we need If-Range, but, can't hurt.