### PR TITLE
Add galaxyproject.org cache purge, update 404

### DIFF
--- a/env/galaxy/templates/nginx/galaxyproject.j2
+++ b/env/galaxy/templates/nginx/galaxyproject.j2
@@ -4,8 +4,13 @@
 
 proxy_cache_path    /var/lib/nginx/cache levels=1:2 keys_zone=s3_cache:10m max_size=128m inactive=60m use_temp_path=off;
 
+geo $purge_allowed {
+   default              0;  # deny from all
+   128.118.250.0/24     1;  # allow from jenkins
+}
+
 map $request_method $purge_method {
-    PURGE 1;
+    PURGE   $purge_allowed;
     default 0;
 }
 

--- a/env/galaxy/templates/nginx/galaxyproject.j2
+++ b/env/galaxy/templates/nginx/galaxyproject.j2
@@ -4,6 +4,11 @@
 
 proxy_cache_path    /var/lib/nginx/cache levels=1:2 keys_zone=s3_cache:10m max_size=128m inactive=60m use_temp_path=off;
 
+map $request_method $purge_method {
+    PURGE 1;
+    default 0;
+}
+
 server {
     listen      *:443 ssl;
     server_name www.galaxyproject.org;
@@ -104,6 +109,7 @@ server {
 
     location / {
         proxy_cache            s3_cache;
+        proxy_cache_purge      $purge_method;
         proxy_http_version     1.1;
         proxy_set_header       Connection "";
         proxy_set_header       Authorization '';

--- a/env/galaxy/templates/nginx/galaxyproject.j2
+++ b/env/galaxy/templates/nginx/galaxyproject.j2
@@ -2,7 +2,7 @@
 ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
 ##
 
-proxy_cache_path    /var/lib/nginx/cache levels=1:2 keys_zone=s3_cache:10m max_size=128m inactive=60m use_temp_path=off;
+proxy_cache_path    /var/lib/nginx/cache levels=1:2 keys_zone=s3_cache:10m max_size=128m inactive=60m use_temp_path=off purger=on;
 
 geo $purge_allowed {
    default              0;  # deny from all

--- a/env/galaxy/templates/nginx/galaxyproject.j2
+++ b/env/galaxy/templates/nginx/galaxyproject.j2
@@ -34,8 +34,8 @@ server {
 
     #root        /srv/nginx/galaxyproject.org/root;
 
-    error_page  404      /page-not-found/;
-    error_page  403 =404 /page-not-found/;
+    error_page  404      /404/;
+    error_page  403 =404 /404/;
 
     # old static conference pages
     rewrite (?i)^/(dev2010|gcc2011)$ /$1/;


### PR DESCRIPTION
This will allow us to manually clear cache on hub builds, and it updates the 404 to point to the hub's 404 page.