### PR TITLE
GTN:GA4GH TRS endpoint support rewrite

### DIFF
--- a/env/galaxy/templates/nginx/training.j2
+++ b/env/galaxy/templates/nginx/training.j2
@@ -71,6 +71,12 @@ server {
         proxy_pass             https://galaxyproject.github.io/training-material/;
     }
 
+    location ~ ^/training-material/api/ga4gh/(.*) {
+        proxy_http_version     1.1;
+        proxy_set_header       Host galaxyproject.github.io;
+        proxy_pass             https://galaxyproject.github.io/training-material/api/ga4gh/\1.json;
+    }
+
     location / {
         proxy_cache            s3_cache;
         proxy_http_version     1.1;


### PR DESCRIPTION
GA4GH TRS endpoints expect paths ending in nothing, no trailing slash. They additionally have the structure

/blah/1
/blah/1/GALAXY/descriptor

Which obviously doesn't work since we aren't responding to an exact URL but trying to map it to a file. So internally we will call the files 1.json and descriptor.json, and then have nginx strip that out so it just all works

I believe this should work but would appreciate a sanity check @natefoo 