### PR TITLE
Create a redirect loop to usegalaxy.eu (urgent)

### DIFF
--- a/env/galaxy/templates/nginx/galaxyproject.j2
+++ b/env/galaxy/templates/nginx/galaxyproject.j2
@@ -28,7 +28,7 @@ server {
     error_page  403 =404 /404/;
 
     # create a redirect loop to usegalaxy.eu
-    # During the 11th and 12th of June 2023, visitors
+    # During the 12th and 13th of June 2023, visitors
     # of usegalaxy.eu were redirected to this blog
     # post, but using a 301 HTTP redirect. This kind
     # of redirect is cached forever by most browsers.

--- a/env/galaxy/templates/nginx/galaxyproject.j2
+++ b/env/galaxy/templates/nginx/galaxyproject.j2
@@ -27,6 +27,22 @@ server {
     error_page  404      /404/;
     error_page  403 =404 /404/;
 
+    # create a redirect loop to usegalaxy.eu
+    # During the 11th and 12th of June 2023, visitors
+    # of usegalaxy.eu were redirected to this blog
+    # post, but using a 301 HTTP redirect. This kind
+    # of redirect is cached forever by most browsers.
+    # Those users need now to clear the browser's cache
+    # to access usegalaxy.eu again, but if the news do
+    # not reach them, or they do not know how to clear
+    # the cache, then they will think that uselaxy.eu
+    # is down forever. As a a workaround, this
+    # directive creates a redirection loop, which should
+    # invalidate the cache for most browsers.
+    location ~ ^/news/2023-06-06-eu-maintenance(.*) {
+      return 302 https://usegalaxy.eu/;
+    }
+
     # old static conference pages
     rewrite (?i)^/(dev2010|gcc2011)$ /$1/;
     location ~ (?i)^/(dev2010|gcc2011)/(.*) {


### PR DESCRIPTION
During the 12th and 13th of June 2023, visitors of usegalaxy.eu were redirected to a blog post (because of maintenance operations), but using a 301 HTTP redirect. This kind of redirect is cached forever by most browsers. Those users need now to clear the browser's cache to access usegalaxy.eu again, but if the news do not reach them, or they do not know how to clear the cache, then they will think that usegalaxy.eu is down forever. As a a workaround, this directive creates a redirection loop, which should invalidate the cache for most browsers.

For a better understanding, this StackOverflow question is a good reference: https://stackoverflow.com/questions/9130422/how-long-do-browsers-cache-http-301s