### PR TITLE
Tweak tool shed config

### DIFF
--- a/group_vars/tool_shed_servers/vars.yaml
+++ b/group_vars/tool_shed_servers/vars.yaml
@@ -88,14 +88,14 @@ tool_shed_log_dir: "{{ tool_shed_root }}/log"
 tool_shed_repos_dir: "{{ tool_shed_mutable_data_dir }}/repos"
 
 ## used by: systemd templates
-tool_shed_gunicorn_workers: 1
+tool_shed_gunicorn_workers: 2
 tool_shed_gunicorn_bind: "127.0.0.1:9009"
-tool_shed_gunicorn_max_requests: 50000
+tool_shed_gunicorn_max_requests: 500000
 tool_shed_gunicorn_max_requests_jitter: 5000
 tool_shed_hgweb_dir: "{{ tool_shed_root }}/hgweb"
 tool_shed_hgweb_user: shedweb
 tool_shed_hgweb_group: shed
-tool_shed_hgweb_gunicorn_workers: 2
+tool_shed_hgweb_gunicorn_workers: 4
 tool_shed_hgweb_gunicorn_bind: "127.0.0.1:3003"
 tool_shed_hgweb_max_requests: 500
 tool_shed_hgweb_max_requests_jitter: 50

--- a/host_vars/eddie.galaxyproject.org/vars.yaml
+++ b/host_vars/eddie.galaxyproject.org/vars.yaml
@@ -91,8 +91,8 @@ tool_shed_instance_codename: test
 tool_shed_instance_hostname: testtoolshed.g2.bx.psu.edu
 tool_shed_version: dev
 tool_shed_config_ga_code: "UA-45719423-8"
-tool_shed_gunicorn_memory_limit: 10G
-tool_shed_hgweb_memory_limit: 2G
+tool_shed_gunicorn_memory_limit: 4G
+tool_shed_hgweb_memory_limit: 1G
 
 ## used by: error_pages
 error_pages_title: "Galaxy Tool Shed (sandbox for testing)"

--- a/host_vars/radegast.galaxyproject.org/vars.yaml
+++ b/host_vars/radegast.galaxyproject.org/vars.yaml
@@ -114,8 +114,8 @@ tool_shed_instance_codename: main
 tool_shed_instance_hostname: toolshed.g2.bx.psu.edu
 tool_shed_version: release_26.0
 tool_shed_config_ga_code: "UA-45719423-12"
-tool_shed_gunicorn_memory_limit: 10G
-tool_shed_hgweb_memory_limit: 2G
+tool_shed_gunicorn_memory_limit: 4G
+tool_shed_hgweb_memory_limit: 1G
 
 ## used by: error_pages
 error_pages_title: "Galaxy Tool Shed"

--- a/templates/nginx/toolshed.j2
+++ b/templates/nginx/toolshed.j2
@@ -32,6 +32,10 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
         proxy_set_header   SCRIPT_NAME       {{ tool_shed_hgweb_prefix }};
     }
+
+    location ~ ^{{ tool_shed_hgweb_prefix.rstrip("/") }}/.*/annotate/ {
+        return 403;
+    }
 {% endif %}
 
 {% if tool_shed_api_version == "v2" %}


### PR DESCRIPTION
Steady state memory of tool shed process is way down since we don't load all repos into memory anymore. Dropped max mem for shed app to 4GB. Dropped hgweb max mem to 1GB. Doubled both worker counts. Disabled /annotate andpoint used by hgweb's annotate function, which is very CPU intensive.