### PR TITLE
Exempt /_job_file from rate limit on test

### DIFF
--- a/templates/nginx/galaxy_test.j2
+++ b/templates/nginx/galaxy_test.j2
@@ -29,6 +29,7 @@ map $request_uri $path_exempt {
     ~^/api/upload/resumable_upload "exempt";
     ~^/api/job_files "exempt";
     ~^/api/jobs/[^/]+/files "exempt";
+    ~^/_job_files "exempt";
     default "not_exempt";
 }
 
@@ -89,12 +90,11 @@ server {
     }
 
     # Rate limit all API endpoints (except those exempted via map: tusd, job_files)
-    # FIXME: somehow this is also hitting /_job_files (even with /api/jobs/<job_id>/files exempt) but not on Main??
-    #location /api/ {
-    #    limit_req zone=limit_test burst=40 nodelay;
-    #    limit_req_status 429;
-    #    try_files false @galaxy;
-    #}
+    location /api/ {
+        limit_req zone=limit_test burst=40 nodelay;
+        limit_req_status 429;
+        try_files false @galaxy;
+    }
 
     location @galaxy {
         proxy_pass         http://galaxy;


### PR DESCRIPTION
The`/_job_files` endpoint uses nginx_upload_module, which rewrites to
`/api/jobs/<id>/files` after upload. This rewrite causes the request to
match `location /api/` and hit rate limiting. However, the exemption
map checks $request_uri (the original client URL), which is still
`/_job_files` — not matching any /api/... exemption patterns.

Added `/_job_files` to the path exemption map and re-enabled rate limiting.
Main is unaffected because it doesn't use nginx_upload_module for job
files.