### PR TITLE
Register gpt-oss-120b on the LiteLLM proxy

### DIFF
--- a/group_vars/litellm_servers/vars.yaml
+++ b/group_vars/litellm_servers/vars.yaml
@@ -32,6 +32,12 @@ litellm_models:
       api_base: "https://llm.jetstream-cloud.org/sglang/v1"
       api_key: "dummy-key"
       verify: "{{ litellm_model_api_verify_ssl }}"
+  - model_name: "gpt-oss-120b"
+    litellm_params:
+      model: "openai/gpt-oss-120b"
+      api_base: "https://llm.jetstream-cloud.org/gpt-oss-120b/v1"
+      api_key: "dummy-key"
+      verify: "{{ litellm_model_api_verify_ssl }}"
 
 litellm_master_key: "{{ vault_litellm_master_key }}"
 


### PR DESCRIPTION
Adds `gpt-oss-120b` to the `litellm_models` list, routed to the existing Jetstream2 endpoint at `https://llm.jetstream-cloud.org/gpt-oss-120b/v1`.

Jetstream2 [offers three models](https://docs.jetstream-cloud.org/inference-service/overview/) on their inference service but we were only exposing two. Galaxy AI agents on test are pointed at `gpt-oss-120b` and were getting back `Invalid model name passed in model=gpt-oss-120b`.