### PR TITLE
Fix GTN video proxy location

### DIFF
--- a/templates/nginx/training.j2
+++ b/templates/nginx/training.j2
@@ -49,7 +49,7 @@ server {
         proxy_pass             http://galaxy-training.s3-website.us-east-1.amazonaws.com/archive;
     }
     
-    location /videos/topic {
+    location /videos/topics {
         proxy_cache            s3_cache;
         proxy_http_version     1.1;
         proxy_set_header       Connection "";
@@ -70,7 +70,7 @@ server {
         proxy_cache_valid      200 304 60m;
         add_header             Cache-Control max-age=31536000;
         add_header             X-Cache-Status $upstream_cache_status;
-        proxy_pass             http://galaxy-training.s3-website.us-east-1.amazonaws.com/videos/topic;
+        proxy_pass             http://galaxy-training.s3-website.us-east-1.amazonaws.com/videos/topics;
     }
 
     location /training-material/ {


### PR DESCRIPTION
@natefoo Hoping to fix the GTN issue with automated videos not displaying (https://github.com/galaxyproject/training-material/issues/6911).

the location should be topics (plural), but in the nginx config it was singular. Clearly it used to work before but not anymore
 

