### PR TITLE
Fix GTN video proxy location in CloudFront

### DIFF
--- a/host_vars/cloudfront-gtn/vars.yaml
+++ b/host_vars/cloudfront-gtn/vars.yaml
@@ -5,7 +5,7 @@
 
 # There is no correlation between this version and the Lambda ARN version
 lambda_function_version: "1"
-cloudfront_distribution_version: "1"
+cloudfront_distribution_version: "2"
 
 aws_region: us-east-1
 
@@ -101,7 +101,7 @@ cloudfront_cache_behaviors:
     smooth_streaming: false
     # Managed-CachingOptimized
     cache_policy_id: 658327ea-f89d-4fab-a63d-7e88639e58f6
-  - path_pattern: /videos/topic/*
+  - path_pattern: /videos/topics/*
     target_origin_id: galaxy-training.s3-website.us-east-1.amazonaws.com
     viewer_protocol_policy: redirect-to-https
     allowed_methods:


### PR DESCRIPTION
This is already deployed, and left behind the `/videos/topic/*` origin, I guess that will have to be removed by hand, kind of surprised that's how the cloudfront_distribution module works (the list in `origins` does not replace origins, it adds/updates).