### PR TITLE
Add procstat telegraf plugins for gunicorn web services

### DIFF
--- a/group_vars/galaxy_main_web_servers/vars.yaml
+++ b/group_vars/galaxy_main_web_servers/vars.yaml
@@ -69,3 +69,16 @@ galaxy_main_web_servers_group_telegraf_plugins_extra:
       - timeout = "10s"
       - data_format = "influx"
       - interval = "1m"
+  # Per-PID memory for the two gunicorn web services so worker RSS/CoW growth is
+  # captured historically (the 2026-06-30 memory surge could not be reconstructed
+  # because only host-level mem was collected here). One block per bind port.
+  procstat_gunicorn_0:
+    plugin: procstat
+    config:
+      - pattern = "fast_factory.*0.0.0.0:8080"
+      - 'user = "{{ galaxy_user }}"'
+  procstat_gunicorn_1:
+    plugin: procstat
+    config:
+      - pattern = "fast_factory.*0.0.0.0:8081"
+      - 'user = "{{ galaxy_user }}"'


### PR DESCRIPTION
## What

Adds per-PID `procstat` telegraf plugins for both gunicorn web services (`:8080` / `:8081`) on `galaxy_main_web_servers`.

## Why

During the 2026-06-30 memory + load surge on main1/main2, the web nodes only collected **host-level** memory (`mem.used`), so the incident could not be reconstructed per-process — we had to fall back to live `smaps`/`ps` and log forensics. The handler group already ships `procstat`; this brings the web nodes to parity so worker RSS / CoW growth is captured historically and the next occurrence is a Grafana lookup.

## Notes

- Keyed on the bind port (`-b 0.0.0.0:8080`/`:8081`) — the only per-service discriminator in the cmdline — which preserves the @0/@1 split (they behaved differently in the incident: @1 throttled, @0 didn't) and excludes the backup-staging gunicorn.
- Verified on galaxy-main1: each pattern resolves to exactly its service's master + 4 workers.
- Telegraf-only change — deploy does not recycle gunicorn.
- Does **not** touch `--max-requests` / memory limits / swap; those mitigations are intentionally left for a separate change.