### PR TITLE
Pin community.general to 11.4.9 for zpool module

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -48,6 +48,9 @@ roles:
 collections:
   - name: galaxyproject.general
     version: 1.4.1
+  # Pinned for community.general.zpool (added in 11.0.0), used by galaxyproject.general's paths role
+  - name: community.general
+    version: 11.4.9
   - name: community.grafana
     version: 1.1.0
   - name: community.rabbitmq


### PR DESCRIPTION
## Problem

Running the pulsar/paths playbook fails with:

```
ERROR! couldn't resolve module/action 'community.general.zpool'
```

in `galaxyproject.general`'s `paths` role ("Create ZFS zpools" task).

## Root cause

- The `paths` role in `galaxyproject.general` **1.4.1** uses the `community.general.zpool` module, which was **added in `community.general` 11.0.0**.
- `galaxyproject.general` declares `dependencies: {}`, so it does not pull in a compatible `community.general`.
- `requirements.yml` never pinned `community.general`, so hosts fell back to an older version (installed transitively by `community.docker`/`community.grafana`/`community.rabbitmq`) that lacks the `zpool` module.

## Fix

Pin `community.general` to **11.4.9** — the latest 11.x release that ships the `zpool` module while keeping the ansible-core floor at `>=2.16`.

## Deploy note

Hosts need a forced collection reinstall to replace the stale version:

```bash
ansible-galaxy collection install -r requirements.yml --force
```

ansible-core must be `>= 2.16`.