### PR TITLE
Fix non-boolean conditionals rejected by ansible-core 2.19+

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -41,7 +41,7 @@
     file:
       dest: /etc/systemd/system/docker.service.d
       state: directory
-    when: docker_daemon_option_list
+    when: docker_daemon_option_list | length > 0
 
   - name: Set docker daemon startup options
     copy:
@@ -56,7 +56,7 @@
     notify:
       - reload systemd daemon
       - restart docker
-    when: docker_daemon_option_list
+    when: docker_daemon_option_list | length > 0
 
   - name: Start or stop docker as desired
     service:

--- a/roles/tool_shed_privileged/tasks/main.yml
+++ b/roles/tool_shed_privileged/tasks/main.yml
@@ -98,7 +98,7 @@
   environment:
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ tool_shed_venv_dir }}"
-  when: tool_shed_additional_venv_packages
+  when: tool_shed_additional_venv_packages | length > 0
   tags: update
 
 - name: Tool Shed v1 Block

--- a/roles/usegalaxy_org.smartos_hypervisor/tasks/main.yaml
+++ b/roles/usegalaxy_org.smartos_hypervisor/tasks/main.yaml
@@ -89,7 +89,7 @@
     state: present
     extra_zfs_properties:
       compression: "{{ smartos_hypervisor_zones_compression }}"
-  when: smartos_hypervisor_zones_compression
+  when: smartos_hypervisor_zones_compression is truthy
 
 - name: Disable compression on zones block
   when: not smartos_hypervisor_zones_compression


### PR DESCRIPTION
Ansible 2.19 requires `when:` to evaluate to a boolean. Bare non-boolean conditionals, which previously meant "truthy if non-empty", now fail hard:

```
Conditional result (True) was derived from value of type 'list' ...
Conditionals must have a boolean result.
```

This broke the `tool_shed_privileged` *Install Tool Shed additional packages* task against eddie, since `tool_shed_additional_venv_packages` is a list. Two other roles had the same latent bug.

| File | Change |
|---|---|
| `roles/tool_shed_privileged/tasks/main.yml` | `| length > 0` |
| `roles/docker/tasks/main.yml` (x2) | `| length > 0` |
| `roles/usegalaxy_org.smartos_hypervisor/tasks/main.yaml` | `is truthy` |

The two styles are deliberate. `tool_shed_additional_venv_packages` and `docker_daemon_option_list` both default to `[]` in their roles and are always lists, so `| length > 0` is exact and matches the style used elsewhere in the repo. `smartos_hypervisor_zones_compression` is tri-state — a compression algorithm string such as `lz4`, or falsy to disable — so `| length > 0` would break if it were ever set to `false`; `is truthy` preserves the original semantics across strings, lists, and booleans.

Its paired `when: not smartos_hypervisor_zones_compression` needs no change — `not` already yields a real boolean.

## Verification

Reproduced the original error on ansible-core 2.20 and confirmed the replacements run on a non-empty list and skip on an empty one, so the `[]` defaults still short-circuit as before.

Also swept the rest of `roles/` for the same bug class, including list-form conditionals and `and`/`or` chains (which in Jinja return an operand rather than a bool, so they can hide this). The remaining bare conditionals — `__kerberos_redhat`, `__ldap_redhat`, `__hashicorp_vault_is_sealed`, `__sentry_run_install_script` — are genuinely boolean and unaffected.